### PR TITLE
ci: implement full-stack quality gate in deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy Full Stack
+    name: Test and Deploy Full Stack
     runs-on: ubuntu-latest
 
     steps:
@@ -23,11 +23,19 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          # Wir zeigen auf infra, damit der Cache-Check nicht fehlschlägt
           cache-dependency-path: |
             infra/package-lock.json
             backend/package-lock.json
             frontend/package-lock.json
+
+      - name: Install all dependencies
+        run: npm run install-all
+
+      - name: Run all tests (Monorepo)
+        run: npm run test
+
+      - name: Build Frontend
+        run: npm run build --prefix frontend
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -35,14 +43,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'eu-central-1' }}
           role-session-name: GitHubActions-Deploy
-
-      # Nutze dein zentrales Script aus dem Root
-      - name: Install all dependencies
-        run: npm run install-all
-
-      # Optional: Frontend Build (notwendig für das spätere Hosting Issue #32)
-      - name: Build Frontend
-        run: npm run build --prefix frontend
 
       - name: Deploy with CDK
         run: |

--- a/docs/adr/007-manual-bootstrapping-oidc.md
+++ b/docs/adr/007-manual-bootstrapping-oidc.md
@@ -1,0 +1,21 @@
+# ADR 007: Manual Bootstrapping of OIDC Infrastructure
+
+## Status
+Accepted
+
+## Date
+2026-01-08
+
+## Context
+The project uses GitHub Actions with OIDC for authentication. A `cdk destroy` operation removed the IAM OIDC Provider and the deployment role, creating a "circular dependency" where the pipeline cannot deploy the permissions it needs to run.
+
+## Decision
+We will perform a one-time manual deployment from a local developer machine using administrative credentials. 
+
+**Strategic Justification:**
+This approach is accepted for the **MVP (Minimum Viable Product)** phase to increase **Time-to-Market**. Instead of engineering a complex automated recovery now, we prioritize restoring the feature-delivery pipeline immediately.
+
+## Consequences
+- **Positive:** Restores the CI/CD pipeline immediately; allows focus on frontend/backend features.
+- **Negative:** Manual step required after any full stack destruction.
+- **Future Work:** Transition to a decoupled CI/CD infrastructure stack to prevent this in the production phase.


### PR DESCRIPTION
- Add 'npm run test' execution before build and deployment phases
- Ensure deployment is blocked if any of the 125+ tests fail
- Move AWS credential configuration after successful test execution for improved security