### PR TITLE
Refactor/extract shared backend utils

### DIFF
--- a/backend/interfaces/ImageMetadata.ts
+++ b/backend/interfaces/ImageMetadata.ts
@@ -1,0 +1,62 @@
+/**
+ * ImageMetadata Interface
+ * 
+ * Represents the structure of image metadata stored in DynamoDB.
+ */
+export interface ImageMetadata {
+  imageId: string;
+  s3Url: string;
+  labels: Array<Label>;
+  timestamp: string;
+}
+
+/**
+ * Type Guard for {@link ImageMetadata}
+ * @param obj Object to be checked if it conforms to ImageMetadata
+ * @returns True if obj is ImageMetadata, false otherwise
+ */
+export function isImageMetadata(obj: unknown): obj is ImageMetadata {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    ('imageId' in obj && typeof obj.imageId === 'string') &&
+    ('s3Url' in obj && typeof obj.s3Url === 'string') &&
+    'labels' in obj &&
+    Array.isArray(obj.labels) &&
+    obj.labels.every(isLabel) &&
+    ('timestamp' in obj && typeof obj.timestamp === 'string')
+  );
+}
+
+/**
+ * Type Guard for array of {@link ImageMetadata}
+ * @param obj Object to be checked if it is an array of ImageMetadata
+ * @returns True if obj is an array of ImageMetadata, false otherwise
+ */
+export function isImageMetadataArray(obj: unknown): obj is ImageMetadata[] {
+  return Array.isArray(obj) && obj.every(isImageMetadata);
+}
+
+/**
+ * Label Interface
+ * 
+ * @see {@link ImageMetadata}
+ */
+export interface Label {
+  name: string;
+  confidence: number;
+}
+
+/**
+ * Type Guard for {@link Label}
+ * @param obj Object to be checked if it conforms to Label
+ * @returns True if obj is Label, false otherwise
+ */
+export function isLabel(obj: unknown): obj is Label {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    ('name' in obj && typeof obj.name === 'string') &&
+    ('confidence' in obj && typeof obj.confidence === 'number')
+  );
+}

--- a/backend/interfaces/PresignedUrlResponse.ts
+++ b/backend/interfaces/PresignedUrlResponse.ts
@@ -1,0 +1,26 @@
+/**
+ * PresignedUrlResponse Interface
+ * 
+ * Architectural Decision: Defining a strict TypeScript interface for the API response
+ * ensures type safety and makes the expected response structure explicit for consumers.
+ */
+export interface PresignedUrlResponse {
+    uploadUrl: string;
+    key: string;
+    expiresIn: number;
+}
+
+/**
+ * Type Guard for {@link PresignedUrlResponse}
+ * @param obj Object to be checked if it conforms to PresignedUrlResponse
+ * @returns True if obj is PresignedUrlResponse, false otherwise
+ */
+export function isPresignedUrlResponse(obj: unknown): obj is PresignedUrlResponse {
+    return (
+        typeof obj === 'object' &&
+        obj !== null &&
+        ('uploadUrl' in obj && typeof obj.uploadUrl === 'string') &&
+        ('key' in obj && typeof obj.key === 'string') &&
+        ('expiresIn' in obj && typeof obj.expiresIn === 'number')
+    );
+}

--- a/backend/interfaces/index.ts
+++ b/backend/interfaces/index.ts
@@ -1,0 +1,4 @@
+export { isImageMetadata, isImageMetadataArray, isLabel } from './ImageMetadata'
+export type { ImageMetadata, Label } from './ImageMetadata.ts'
+export { isPresignedUrlResponse } from './PresignedUrlResponse'
+export type { PresignedUrlResponse } from './PresignedUrlResponse.ts'

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -9,4 +9,8 @@ module.exports = {
     '!**/node_modules/**',
     '!**/test/**',
   ],
+  moduleNameMapper: {
+    '^lib$': '<rootDir>/lib/index.ts',
+    '^interfaces$': '<rootDir>/interfaces/index.ts',
+  },
 };

--- a/backend/lib/env.ts
+++ b/backend/lib/env.ts
@@ -1,0 +1,81 @@
+/**
+ * Get the DynamoDB table name from environment variables
+ * @returns DynamoDB table name
+ * @throws Error if the environment variable is not set or not a string
+ */
+export function getEnvTableName(): string {
+  return getEnvStringVar('TABLE_NAME');
+}
+
+/**
+ * Get the S3 bucket name from environment variables
+ * @returns S3 bucket name
+ * @throws Error if the environment variable is not set or not a string
+ */
+export function getEnvBucketName(): string {
+  return getEnvStringVar('BUCKET_NAME');
+}
+
+/**
+ * Get the CloudFront domain from environment variables
+ * @returns CloudFront domain
+ * @throws Error if the environment variable is not set or not a string
+ */
+export function getEnvCloudFrontDomain(): string {
+  return getEnvStringVar('CLOUDFRONT_DOMAIN');
+}
+
+/**
+ * Get the maximum number of labels for Rekognition from environment variables
+ * @returns Maximum number of labels for Rekognition
+ */
+export function getEnvRekognitionMaxLabels(defaultValue = 10): number {
+  return getEnvIntVar('REKOGNITION_MAX_LABELS', parseInt, defaultValue);
+}
+
+/**
+ * Get the minimum confidence for Rekognition from environment variables
+ * @returns Minimum confidence for Rekognition
+ */
+export function getEnvRekognitionMinConfidence(defaultValue = 70): number {
+  return getEnvIntVar('REKOGNITION_MIN_CONFIDENCE', parseFloat, defaultValue);
+}
+
+/**
+ * Helper function to retrieve and validate string environment variables
+ * @param varName Name of the environment variable
+ * @returns Value of the environment variable
+ * @throws Error if the environment variable is not set or not a string
+ */
+function getEnvStringVar(varName: string): string {
+  const value = process.env[varName];
+  if (!value) {
+    throw new Error(`${varName} environment variable is not set`);
+  }
+  return value;
+}
+
+/**
+ * Helper function to retrieve and validate integer environment variables
+ * @param varName Name of the environment variable
+ * @param parser Function to parse the string value to an integer
+ * @param defaultValue Optional default value if the environment variable is not set
+ * @returns Integer value of the environment variable
+ * @throws Error if no default value is provided and the environment variable 
+ *          is not set or not a valid integer
+ */
+function getEnvIntVar(
+  varName: string,
+  parser: (value: string, radix?: number) => number,
+  defaultValue?: number
+): number {
+  const value = process.env[varName];
+  if (!value && defaultValue === undefined) {
+    throw new Error(`${varName} environment variable is not set`);
+  }
+  const intValue = value ? parser(value, 10) : defaultValue!;
+  if (isNaN(intValue)) {
+    throw new Error(`${varName} environment variable must be a valid integer`);
+  }
+  return intValue;
+}

--- a/backend/lib/env.ts
+++ b/backend/lib/env.ts
@@ -30,7 +30,7 @@ export function getEnvCloudFrontDomain(): string {
  * @returns Maximum number of labels for Rekognition
  */
 export function getEnvRekognitionMaxLabels(defaultValue = 10): number {
-  return getEnvIntVar('REKOGNITION_MAX_LABELS', parseInt, defaultValue);
+  return getEnvNumberVar('REKOGNITION_MAX_LABELS', parseInt, defaultValue);
 }
 
 /**
@@ -38,7 +38,7 @@ export function getEnvRekognitionMaxLabels(defaultValue = 10): number {
  * @returns Minimum confidence for Rekognition
  */
 export function getEnvRekognitionMinConfidence(defaultValue = 70): number {
-  return getEnvIntVar('REKOGNITION_MIN_CONFIDENCE', parseFloat, defaultValue);
+  return getEnvNumberVar('REKOGNITION_MIN_CONFIDENCE', parseFloat, defaultValue);
 }
 
 /**
@@ -56,15 +56,15 @@ function getEnvStringVar(varName: string): string {
 }
 
 /**
- * Helper function to retrieve and validate integer environment variables
+ * Helper function to retrieve and validate number environment variables
  * @param varName Name of the environment variable
- * @param parser Function to parse the string value to an integer
+ * @param parser Function to parse the string value to a number
  * @param defaultValue Optional default value if the environment variable is not set
- * @returns Integer value of the environment variable
+ * @returns Number value of the environment variable
  * @throws Error if no default value is provided and the environment variable 
  *          is not set or not a valid integer
  */
-function getEnvIntVar(
+function getEnvNumberVar(
   varName: string,
   parser: (value: string, radix?: number) => number,
   defaultValue?: number

--- a/backend/lib/index.ts
+++ b/backend/lib/index.ts
@@ -1,0 +1,9 @@
+export {
+    getEnvTableName,
+    getEnvBucketName,
+    getEnvCloudFrontDomain,
+    getEnvRekognitionMaxLabels,
+    getEnvRekognitionMinConfidence
+} from './env'
+export { createErrorResponse, createSuccessResponse } from './response'
+export type { ErrorStatusCode } from './response.ts'

--- a/backend/lib/response.ts
+++ b/backend/lib/response.ts
@@ -1,0 +1,68 @@
+import { APIGatewayProxyResultV2 } from "aws-lambda";
+
+/**
+ * CORS Headers
+ * 
+ * Architectural Decision: Allow cross-origin requests from any origin (*).
+ * This is acceptable for a public read-only API endpoint.
+ * 
+ * For production, consider restricting to specific origins:
+ * 'Access-Control-Allow-Origin': 'https://yourdomain.com'
+ */
+const CORS_HEADERS = {
+    'Access-Control-Allow-Origin': '*',
+};
+
+export type ErrorStatusCode = 400 | 500;
+const ERROR_STATUS_CODE_MESSAGE_MAP: Record<ErrorStatusCode, string> = {
+    400: 'Bad request',
+    500: 'Internal server error',
+};
+
+/**
+ * Create a standardized error response
+ * Logs the error message and optional error object to console
+ * @param statusCode HTTP status code for the error
+ * @param message Detailed error message; can be string or Error object
+ * @param error Optional error object for raw logging
+ * @returns Standardized error response object
+ */
+export function createErrorResponse(
+    statusCode: ErrorStatusCode,
+    message: string | Error | unknown,
+    error?: unknown
+): APIGatewayProxyResultV2 {
+    const _message = message instanceof Error ? message.message : String(message);
+    if (error)
+        console.error(`${_message}:`, error);
+    else
+        console.error(`${_message}`);
+    return {
+        statusCode,
+        headers: {
+            'Content-Type': 'application/json',
+            ...CORS_HEADERS,
+        },
+        body: JSON.stringify({ error: ERROR_STATUS_CODE_MESSAGE_MAP[statusCode], message: _message }),
+    };
+}
+
+/**
+ * Create a standardized success response
+ * If no data is provided, returns 204 No Content else 200 OK with data
+ * @param data Optional data to include in the response body as JSON
+ * @returns Standardized success response object
+ */
+export function createSuccessResponse(
+    data?: unknown
+): APIGatewayProxyResultV2 {
+    const hasBody = data !== undefined;
+    return {
+        statusCode: hasBody ? 200 : 204,
+        headers: {
+            ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+            ...CORS_HEADERS,
+        },
+        body: hasBody ? JSON.stringify(data) : undefined,
+    };
+}

--- a/backend/test/delete-image.test.ts
+++ b/backend/test/delete-image.test.ts
@@ -236,12 +236,12 @@ describe('DeleteImage Lambda Handler', () => {
     
     const body = JSON.parse(response.body as string);
     expect(body).toEqual({
-      error: 'Bad Request',
+      error: 'Bad request',
       message: 'imageId is required in path parameters',
     });
-    
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Missing imageId in path parameters');
-    
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('imageId is required in path parameters');
+
     // Verify no AWS SDK calls were made
     expect(s3Mock.calls()).toHaveLength(0);
     expect(dynamoDbMock.calls()).toHaveLength(0);
@@ -340,9 +340,9 @@ describe('DeleteImage Lambda Handler', () => {
       error: 'Internal server error',
       message: 'Failed to delete image',
     });
-    
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error deleting image:', error);
-    
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to delete image:', error);
+
     // Verify S3 delete was called but DynamoDB delete was not (failed before reaching it)
     expect(s3Mock.calls()).toHaveLength(1);
     expect(dynamoDbMock.calls()).toHaveLength(0);
@@ -377,9 +377,9 @@ describe('DeleteImage Lambda Handler', () => {
       error: 'Internal server error',
       message: 'Failed to delete image',
     });
-    
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error deleting image:', error);
-    
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to delete image:', error);
+
     // Verify both S3 and DynamoDB delete were called
     expect(s3Mock.calls()).toHaveLength(1);
     expect(dynamoDbMock.calls()).toHaveLength(1);

--- a/backend/test/get-images.test.ts
+++ b/backend/test/get-images.test.ts
@@ -289,11 +289,8 @@ describe('GetImages Lambda Handler', () => {
       error: 'Internal server error',
       message: 'Failed to retrieve images from database',
     });
-    
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error scanning DynamoDB table:', error);
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error details:', {
-      error: 'ProvisionedThroughputExceededException: Request rate limit exceeded',
-    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to retrieve images from database:', error);
   });
 
   /**
@@ -317,8 +314,8 @@ describe('GetImages Lambda Handler', () => {
     const body = JSON.parse(response.body as string);
     expect(body.error).toBe('Internal server error');
     expect(body.message).toBe('Failed to retrieve images from database');
-    
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error scanning DynamoDB table:', error);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to retrieve images from database:', error);
   });
 
   /**

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "paths": {
+      "lib": [ "lib/index" ],
+      "interfaces": [ "interfaces/index" ]
+    }
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
# Refactor backend lambdas to use shared helpers and interfaces

## Summary

This PR centralizes common backend concerns by introducing shared helpers for environment variable access and API Gateway responses, and by moving response interfaces into dedicated modules. The Lambda handlers are refactored to use these shared utilities, reducing duplication and improving consistency.

## What changed

- Introduced shared helpers under `lib/`:
  - `env` helpers for validated access to required environment variables
  - `response` helpers for standardized success and error responses with CORS
- Refactored Lambda handlers to:
  - replace inline `process.env` access with `getEnv*` helpers
  - replace inline response construction with `createErrorResponse` and `createSuccessResponse`
- Moved API response interfaces into `backend/interfaces`:
  - `ImageMetadata` and `PresignedUrlResponse`
  - added runtime type guards for both
  - added a barrel file for clean imports
- Removed inline interface definitions from Lambda handlers
- Added path aliases for `lib` and `interfaces` in TypeScript and Jest configs
- Updated existing tests to align with the standardized error messages and logging

## Motivation

Previously, each Lambda handled environment validation, error responses, and response typing independently. This led to duplicated logic, subtle inconsistencies in error messages, and unnecessary boilerplate.

By centralizing this logic:
- behavior is consistent across all handlers
- error handling and logging are uniform and easier to reason about
- handlers focus on orchestration instead of infrastructure concerns
- future changes (e.g. stricter validation or different response formats) are localized

## Follow-up work

With the helpers now extracted and stable, the next logical step is to:
- add focused unit tests for the `env` and `response` helpers
- simplify existing Lambda tests to mock these helpers and assert:
  - correct invocation
  - correct control flow and side effects

This will further reduce test duplication and sharpen the separation between business logic and infrastructure concerns.

---

### Tests

The tests are locally green:

```
/serverless-ai-image-tagger/backend (refactor/extract-shared-backend-utils) $ npm run test

> backend@0.1.0 test
> jest

 PASS  test/get-images.test.ts
 PASS  test/delete-image.test.ts
 PASS  test/image-processor.test.ts
 PASS  test/generate-presigned-url.test.ts

Test Suites: 4 passed, 4 total
Tests:       50 passed, 50 total
Snapshots:   0 total
Time:        0.6 s, estimated 1 s
Ran all test suites.
```
